### PR TITLE
Fix broken register_plugin call.

### DIFF
--- a/lib/Dancer/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible.pm
@@ -304,7 +304,7 @@ sub auth_provider {
 }
 
 register_hook qw(login_required permission_denied);
-register_plugin versions => qw(1 2);
+register_plugin for_versions => [qw(1 2)];
 
 # Hook to catch routes about to be executed, and check for attributes telling us
 # we need to make sure the user is auth'd


### PR DESCRIPTION
At least Dancer 2 didn't like it.

t/00-load.t ...... 1/1 
# Failed test 'use Dancer::Plugin::Auth::Extensible;'
# at t/00-load.t line 6.
# Tried to use 'Dancer::Plugin::Auth::Extensible'.
# Error:  Odd number of elements in hash assignment at /home/racke/perl5/perlbrew/perls/perl-5.17.6/lib/site_perl/5.17.6/Dancer/Plugin.pm line 51, <DATA> line 16.

Regards
                 Racke
