### PR TITLE
Pod link typo fix

### DIFF
--- a/lib/Dancer/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible.pm
@@ -46,7 +46,7 @@ Configure the plugin to use the authentication provider class you wish to use:
 
 The configuration you provide will depend on the authentication provider module
 in use.  For a simple example, see
-L<Dancer::Plugin::Auth:Extensible::Provider::Config>.
+L<Dancer::Plugin::Auth::Extensible::Provider::Config>.
 
 Define that a user must be logged in and have the proper permissions to 
 access a route:


### PR DESCRIPTION
There's a missing colon which breaks POD linking
