### PR TITLE
Change the suggested password field from 32 to 40 chars

### DIFF
--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Database.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Database.pm
@@ -110,7 +110,7 @@ something like:
     CREATE TABLE users (
         id       INTEGER     AUTO_INCREMENT PRIMARY KEY,
         username VARCHAR(32) NOT NULL       UNIQUE KEY,
-        password VARCHAR(32) NOT NULL
+        password VARCHAR(40) NOT NULL
     );
 
 You will quite likely want other fields to store e.g. the user's name, email


### PR DESCRIPTION
The SUGGESTED SCHEMA section suggests creating this password field
in the users table:

  password VARCHAR(32) NOT NULL

But the hashed password generated by Crypt::SaltedHash is 39 chars,
so if someone copies this table definition verbatim (like I did)
they will have a password field that is too short, resulting in a
truncated hash and no succesfull logins.
