### PR TITLE
attempt to make LDAP provider to work with generic ldap configurations

### DIFF
--- a/t/02-ldap.t
+++ b/t/02-ldap.t
@@ -31,7 +31,8 @@ my $entries1 = qclass(
 
 my $entry1 = qclass(
     -with_new => 1,
-    vals => {cn => "David Precious", dn => 'dprecious', name => 'David Precious', userPrincipalName => 'dprecious@foo.com', sAMAccountName => 'dprecious'},
+    vals => {cn => "David Precious", dn => 'dprecious', name => 'David Precious', userPrincipalName => 'dprecious@foo.com', sAMAcountName=>'dprecious'},
+#    vals => {dn => 'dprecious', name => 'David Precious', userPrincipalName => 'dprecious@foo.com', cn => 'dprecious'},
     get_value => sub { 
         my $self = shift;
         my $arg = shift;
@@ -57,10 +58,13 @@ my $mod = qclass(
     search => sub {
         my $self = shift;
         my %args = @_;
-        if (my ($uname) = $args{filter} =~ /^\(&\(objectClass=user\)\(sAMAccountName=([^,]+)\)$/) {
+#        if (my ($uname) = $args{filter} =~ /^\(&\(objectClass=user\)\(cn=([^,]+)\)$/) {
+		 if (my ($uname) = $args{filter} =~ /^\(&\(objectClass=user\)\(cn=([^,]+)\)$/) {
+			print "uname = $uname\n";
             return $detail->package->new;
-        } elsif (my ($name, $role) = $args{filter} =~ /^\(\&\(objectClass=user\)\(sAMAccountName=(.+)\)\(memberof=cn=([^,]+)/) {
-            if ($name eq "dprecious") {
+        } elsif (my ($name, $role) = $args{filter} =~ /^\(\&\(memberOf=cn=(.+)\)\("cn="(.+)\)/) {
+#		} elsif (my ($name, $role) = $args{filter} =~ /^\(\&\(objectClass=user\)\(sAMAccountName=(.+)\)\(memberof=cn=([^,]+)/) {
+        if ($name eq "dprecious") {
                 
                 diag("ROLE: " . $role);
                 if ($role eq "Jever" or $role eq "Budvar") {

--- a/t/ldap/config.yml
+++ b/t/ldap/config.yml
@@ -6,9 +6,14 @@ plugins:
                 provider: LDAP
                 server: 127.0.0.1:3333
                 basedn: dc=ofosos,dc=org
+                userdn: dc=ofosos,dc=org
+                userrdn: cn
+                userdetails: cn dn name userPrincipalName
+                objectClass: user
+                rolefilter: memberOf=cn
+                grouprdn: cn
                 authdn: cn=Administrator
                 password: blafasel
-                usergroup: cn=users,dc=ofosos,dc=org
                 roles: Jever,Warsteiner,Budvar
 logger: console
 show_errors: 1


### PR DESCRIPTION
Hello.
I've tried to move to the configuration some parameters to make the ldap provider work with standard LDAP tree without breaking the existing code.
Unfortunately some tests still fail, but It seems that the tests need to be updated.
The provider works on a live system with OpenLDAP.

Thanks, 
Alex