### PR TITLE
Show error on provider load errors to indicate the problem

### DIFF
--- a/lib/Dancer/Plugin/Auth/Extensible.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible.pm
@@ -514,8 +514,11 @@ sub auth_provider {
     if ($provider_class !~ /::/) {
         $provider_class = __PACKAGE__ . "::Provider::$provider_class";
     }
-    Dancer::ModuleLoader->load($provider_class)
-        or die "Cannot load provider $provider_class";
+    my ($ok, $error) = Dancer::ModuleLoader->load($provider_class);
+
+    if (! $ok) {
+        die "Cannot load provider $provider_class: $error";
+    }
 
     return $realm_provider{$realm} = $provider_class->new($realm_settings);
 }


### PR DESCRIPTION
This makes the error message more useful, for example when loading Unix provider without the required
Perl modules:

```
20/Mar/2014 09:56:56 [3354] error @0.011702> request to POST /login crashed: Cannot load provider Dancer::Plugin::Auth::Extensible::Provider::Unix: Can't locate Authen/Simple/PAM.pm in @INC (you may need to install the Authen::Simple::PAM module)
```
