### PR TITLE
Fixed typo in README - 'login_url' should be 'login_page'

### DIFF
--- a/README
+++ b/README
@@ -79,7 +79,7 @@ CONTROLLING ACCESS TO ROUTES
 
         If the user is not logged in, they will be redirected to the login
         page URL to log in. The default URL is `/login' - this may be
-        changed with the `login_url' option.
+        changed with the `login_page' option. Likewise, the logout url can be changed with the 'logout_page' option.
 
     require_role - require the user to have a specified role
             get '/beer' => require_role BeerDrinker => sub { ... };


### PR DESCRIPTION
Can you also confirm if fixing this in the repo's README will fix it here? http://search.cpan.org/~bigpresh/Dancer-Plugin-Auth-Extensible-0.30/lib/Dancer/Plugin/Auth/Extensible.pm