### PR TITLE
Add bin/generate-crypted-password to MANIFEST.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -14,6 +14,7 @@ lib/Dancer/Plugin/Auth/Extensible/Provider/Config.pm
 lib/Dancer/Plugin/Auth/Extensible/Provider/Unix.pm
 lib/Dancer/Plugin/Auth/Extensible/Provider/Base.pm
 lib/Dancer/Plugin/Auth/Extensible.pm
+bin/generate-crypted-password
 MANIFEST
 example/authextest.pl
 example/config.yml


### PR DESCRIPTION
Makefile.PL now expects it, but it also needs to be in the MANIFEST to get in the dist.