### PR TITLE
travis: add YAML to cpanm install list.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ perl:
     - "5.10"
 
 install:
-    - cpanm Dancer Mock::Quick Crypt::SaltedHash --quiet --notest
+    - cpanm Dancer Mock::Quick Crypt::SaltedHash YAML --quiet --notest
 
 script:
     - perl Makefile.PL


### PR DESCRIPTION
This fixes a Travis issue which tripped up the test of my manifest pull request, and had also caused the previous build #89 on the main (bigpresh) repo to fail.