### PR TITLE
Mjg17/kwalitee prereqs perlver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ perl:
     - "5.10"
 
 install:
-    - cpanm Dancer Mock::Quick Crypt::SaltedHash --quiet --notest
+    - cpanm Dancer Mock::Quick Crypt::SaltedHash YAML --quiet --notest
 
 script:
     - perl Makefile.PL

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,14 +20,25 @@ WriteMakefile(
         'YAML'       => 0, # for config files (TODO: make optional?)
         
     },
+    MIN_PERL_VERSION    => 5.006001,
     dist                => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean               => { FILES => 'Dancer-Plugin-Auth-Extensible-*' },
     META_MERGE => {
+        "meta-spec" => { version => 2 },
         resources => {
             repository => 'https://github.com/bigpresh/Dancer-Plugin-Auth-Extensible',
             bugtracker => 'https://github.com/bigpresh/Dancer-Plugin-Auth-Extensible/issues',
             homepage   => 'https://github.com/bigpresh/Dancer-Plugin-Auth-Extensible/',
         },
+        prereqs => {
+            runtime => {
+                recommends => {
+                    'Authen::Simple::PAM'      => 0,
+                    'Dancer::Plugin::Database' => 0,
+                    'Unix::Passwd::File'       => 0,
+                }
+            }
+        }
     },
 
 );


### PR DESCRIPTION
Makefile.PL: specify MIN_PERL_VERSION; add recommended prereqs via META_MERGE.

These should solve some CPANTS issues.

The recommended pre-reqs are needed by the sample plugins, but not for successful testing and installation.

If Dancer::Plugin::Auth::Extensible::Provider::LDAP is ever added to the MANIFEST, then Net::LDAP should be added to the recommended list.

**Note** that I've included my Travis patch in this pull request, so that it passes. I'd recommend merging my Travis pull request first, this should then merge cleanly on top. If not, let me know...