### PR TITLE
Mjg17/kwalitee use warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ perl:
     - "5.10"
 
 install:
-    - cpanm Dancer Mock::Quick Crypt::SaltedHash --quiet --notest
+    - cpanm Dancer Mock::Quick Crypt::SaltedHash YAML --quiet --notest
 
 script:
     - perl Makefile.PL

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Base.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Base.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::Base;
 
 use strict;
+use warnings;
+
 use Crypt::SaltedHash;
 
 =head1 NAME

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Config.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Config.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::Config;
 
 use strict;
+use warnings;
+
 use base "Dancer::Plugin::Auth::Extensible::Provider::Base";
 
 =head1 NAME 

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Database.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Database.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::Database;
 
 use strict;
+use warnings;
+
 use base 'Dancer::Plugin::Auth::Extensible::Provider::Base';
 use Dancer::Plugin::Database;
 use Dancer qw(:syntax);

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Example.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Example.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::Example;
 
 use strict;
+use warnings;
+
 use base "Dancer::Plugin::Auth::Extensible::Provider::Base";
 
 # A more sensible provider would be likely to get this information from e.g. a

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/LDAP.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/LDAP.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::LDAP;
 
 use strict;
+use warnings;
+
 use base "Dancer::Plugin::Auth::Extensible::Provider::Base";
 use Net::LDAP;
 use Dancer qw(warning);

--- a/lib/Dancer/Plugin/Auth/Extensible/Provider/Unix.pm
+++ b/lib/Dancer/Plugin/Auth/Extensible/Provider/Unix.pm
@@ -1,6 +1,8 @@
 package Dancer::Plugin::Auth::Extensible::Provider::Unix;
 
 use strict;
+use warnings;
+
 use base 'Dancer::Plugin::Auth::Extensible::Provider::Base';
 use Authen::Simple::PAM;
 use Unix::Passwd::File;


### PR DESCRIPTION
Add *'use warnings'* to modules.

Although not all may be required, since some other modules export 'warnings', the Kwalitee tests do not know this. Therefore it's easier to make it explicit in each module.

**Note** that I've included my Travis patch in this pull request, so that it passes. I'd recommend merging my Travis pull request first, this should then merge cleanly on top. If not, let me know...